### PR TITLE
약국 도메인 생성 및 Kakao 주소 검색 API 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
     // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
     testImplementation('net.bytebuddy:byte-buddy:1.12.10')
+
+    // testcontainers (도커는 따로 제공하고 있지 않기 때문에 이미지를 받아와서 연동할 예정)
+    testImplementation 'org.testcontainers:spock:1.17.1'
+    testImplementation 'org.testcontainers:mariadb:1.17.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'groovy'
     id 'org.springframework.boot' version '2.6.7'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
@@ -30,6 +31,13 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // spock
+    testImplementation('org.spockframework:spock-core:2.1-groovy-3.0')
+    testImplementation('org.spockframework:spock-spring:2.1-groovy-3.0')
+
+    // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
+    testImplementation('net.bytebuddy:byte-buddy:1.12.10')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/pharmacyrecommendation/BaseTimeEntity.java
+++ b/src/main/java/com/example/pharmacyrecommendation/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.example.pharmacyrecommendation;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/example/pharmacyrecommendation/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/dto/DocumentDto.java
@@ -1,0 +1,21 @@
+package com.example.pharmacyrecommendation.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentDto {
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("y")
+    private double latitude;
+
+    @JsonProperty("x")
+    private double longitude;
+}

--- a/src/main/java/com/example/pharmacyrecommendation/api/dto/KakaoApiResponseDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/dto/KakaoApiResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.pharmacyrecommendation.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoApiResponseDto {
+
+
+    @JsonProperty("meta")
+    private MetaDto metaDto;
+
+    @JsonProperty("documents")
+    private List<DocumentDto> documentList;
+}

--- a/src/main/java/com/example/pharmacyrecommendation/api/dto/MetaDto.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/dto/MetaDto.java
@@ -1,0 +1,15 @@
+package com.example.pharmacyrecommendation.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MetaDto {
+
+    @JsonProperty("total_count")
+    private Integer totalCount;
+}

--- a/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchService.java
@@ -1,0 +1,38 @@
+package com.example.pharmacyrecommendation.api.service;
+
+import com.example.pharmacyrecommendation.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAddressSearchService {
+
+    private final RestTemplate restTemplate;
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestAddressSearch(String address) {
+
+        if(ObjectUtils.isEmpty(address)) return null;
+
+        URI uri = kakaoUriBuilderService.buildUriByAddressSearch(address);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity(headers);
+        //kakao api 호출
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+}

--- a/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoUriBuilderService.java
@@ -1,0 +1,23 @@
+package com.example.pharmacyrecommendation.api.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+public class KakaoUriBuilderService {
+
+    private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    public URI buildUriByAddressSearch(String address) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                .fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL)
+                .queryParam("query", address);
+
+        URI uri = uriBuilder.build().encode().toUri();
+        return uri;
+    }
+}

--- a/src/main/java/com/example/pharmacyrecommendation/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/pharmacyrecommendation/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.pharmacyrecommendation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/entity/Pharmacy.java
@@ -1,0 +1,30 @@
+package com.example.pharmacyrecommendation.pharmacy.entity;
+
+import com.example.pharmacyrecommendation.BaseTimeEntity;
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity(name = "pharmacy")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Pharmacy extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String pharmacyName;
+    private String pharmacyAddress;
+    private double latitude;
+    private double longitude;
+
+    public void changePharmacyAddress(String address) {
+        this.pharmacyAddress = address;
+    }
+}

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/repository/PharmacyRepository.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/repository/PharmacyRepository.java
@@ -1,0 +1,7 @@
+package com.example.pharmacyrecommendation.pharmacy.repository;
+
+import com.example.pharmacyrecommendation.pharmacy.entity.Pharmacy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PharmacyRepository extends JpaRepository<Pharmacy, Long> {
+}

--- a/src/main/java/com/example/pharmacyrecommendation/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/pharmacy/service/PharmacyRepositoryService.java
@@ -1,0 +1,30 @@
+package com.example.pharmacyrecommendation.pharmacy.service;
+
+import com.example.pharmacyrecommendation.pharmacy.entity.Pharmacy;
+import com.example.pharmacyrecommendation.pharmacy.repository.PharmacyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacyRepositoryService {
+    private final PharmacyRepository pharmacyRepository;
+
+    @Transactional
+    public void updateAddress(Long id, String address) {
+        Pharmacy entity = pharmacyRepository.findById(id).orElse(null);
+
+        if(Objects.isNull(entity)) {
+            log.error("[PharmacyRepositoryService update Address] not found id: {}", id);
+            return;
+        }
+
+        entity.changePharmacyAddress(address);
+    }
+
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/AbstractIntegrationContainerBaseTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/AbstractIntegrationContainerBaseTest.groovy
@@ -1,0 +1,21 @@
+package com.example.pharmacyrecommendation
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.containers.GenericContainer
+import spock.lang.Specification
+
+@SpringBootTest
+abstract class AbstractIntegrationContainerBaseTest extends Specification {
+
+    static final GenericContainer MY_REDIS_CONTAINER
+
+    static {
+        MY_REDIS_CONTAINER = new GenericContainer<>("redis:6")
+                .withExposedPorts(6379)
+
+        MY_REDIS_CONTAINER.start()
+
+        System.setProperty("spring.redis.host", MY_REDIS_CONTAINER.getHost())
+        System.setProperty("spring.redis.port", MY_REDIS_CONTAINER.getMappedPort(6379).toString())
+    }
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceTest.groovy
@@ -1,0 +1,34 @@
+package com.example.pharmacyrecommendation.api.service
+
+import com.example.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import org.springframework.beans.factory.annotation.Autowired
+
+class KakaoAddressSearchServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private KakaoAddressSearchService kakaoAddressSearchService
+
+    def "address 파라미터 값이 null이면, requestAddressSearch 메서드는 null을 리턴한다." () {
+        given:
+        String address = null
+
+        when:
+        def result = kakaoAddressSearchService.requestAddressSearch(address)
+
+        then:
+        result == null
+    }
+
+    def "주소값이 valid하다면, requestAddressSearch 메서드는 정상적으로 document를 반환한다." () {
+        given:
+        def address = "서울 성북구 종암로 10길"
+
+        when:
+        def result = kakaoAddressSearchService.requestAddressSearch(address)
+
+        then:
+        result.documentList.size() > 0
+        result.metaDto.totalCount > 0
+        result.documentList.get(0).addressName != null
+    }
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoUriBuilderServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoUriBuilderServiceTest.groovy
@@ -1,0 +1,27 @@
+package com.example.pharmacyrecommendation.api.service
+
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class KakaoUriBuilderServiceTest extends Specification {
+
+    private KakaoUriBuilderService kakaoUriBuilderService;
+
+    def setup() {
+        kakaoUriBuilderService = new KakaoUriBuilderService();
+    }
+
+    def "buildUriByAddressSearch - 한글 파라미터의 경우 정상적으로 인코딩"() {
+        given:
+        String address = "서울 성북구"
+        def charset = StandardCharsets.UTF_8
+
+        when:
+        def uri = kakaoUriBuilderService.buildUriByAddressSearch(address)
+        def decodedResult = URLDecoder.decode(uri.toString(), charset)
+
+        then:
+        decodedResult == "https://dapi.kakao.com/v2/local/search/address.json?query=서울 성북구"
+    }
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/pharmacy/repository/PharmacyRepositoryTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/pharmacy/repository/PharmacyRepositoryTest.groovy
@@ -1,0 +1,82 @@
+package com.example.pharmacyrecommendation.pharmacy.repository
+
+import com.example.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import com.example.pharmacyrecommendation.pharmacy.entity.Pharmacy
+import org.springframework.beans.factory.annotation.Autowired
+
+import java.time.LocalDateTime
+
+class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private PharmacyRepository pharmacyRepository
+
+    def setup() {
+        pharmacyRepository.deleteAll()
+    }
+
+    def "PharmacyRepository save"() {
+        given:
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+        double latitude = 36.11
+        double longitude = 128.11
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build()
+
+        when:
+        def result = pharmacyRepository.save(pharmacy)
+
+        then:
+        result.getPharmacyAddress() == address
+        result.getPharmacyName() == name
+        result.getLatitude() == latitude
+        result.getLongitude() == longitude
+    }
+
+    def "PharmacyRepository saveAll"() {
+        given:
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+        double latitude = 36.11
+        double longitude = 128.11
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build()
+
+        when:
+        pharmacyRepository.saveAll(Arrays.asList(pharmacy))
+        def result = pharmacyRepository.findAll()
+
+        then:
+        result.size() == 1
+    }
+
+    def "BaseTimeEntity 등록"() {
+        given:
+        LocalDateTime now = LocalDateTime.now();
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .build()
+        when:
+        pharmacyRepository.save(pharmacy)
+        def result = pharmacyRepository.findAll();
+
+        then:
+        result.get(0).getCreatedDate().isAfter(now);
+        result.get(0).getModifiedDate().isAfter(now);
+    }
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/pharmacy/service/PharmacyRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/pharmacy/service/PharmacyRepositoryServiceTest.groovy
@@ -1,0 +1,41 @@
+package com.example.pharmacyrecommendation.pharmacy.service
+
+import com.example.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import com.example.pharmacyrecommendation.pharmacy.entity.Pharmacy
+import com.example.pharmacyrecommendation.pharmacy.repository.PharmacyRepository
+import org.springframework.beans.factory.annotation.Autowired
+
+class PharmacyRepositoryServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private PharmacyRepositoryService pharmacyRepositoryService
+
+    @Autowired
+    private PharmacyRepository pharmacyRepository
+
+    def setup() {
+        pharmacyRepository.deleteAll()
+    }
+
+    def "PharmacyRepository update - dirty checking success"() {
+        given:
+        String inputAddress = "서울 특별시 성북구 종암동"
+        String modifiedAddress = "서울 광진구 구의동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .build()
+
+        when:
+        def entity = pharmacyRepository.save(pharmacy)
+        pharmacyRepositoryService.updateAddress(entity.getId(), modifiedAddress);
+
+        def result = pharmacyRepository.findAll();
+
+        then:
+        result.get(0).getPharmacyAddress() == modifiedAddress
+    }
+    
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mariadb:10:///
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}
+      


### PR DESCRIPTION
이 pr은 테스트 환경을 설정하고, 카카오 주소 검색 api를 통해 주소 정보를 받아올 수 있도록 기능을 설계하였다.
This closes #5 