### PR TITLE
Spring Retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,13 @@ dependencies {
     // testcontainers (도커는 따로 제공하고 있지 않기 때문에 이미지를 받아와서 연동할 예정)
     testImplementation 'org.testcontainers:spock:1.17.1'
     testImplementation 'org.testcontainers:mariadb:1.17.1'
+
+    // spring retry
+    implementation 'org.springframework.retry:spring-retry'
+
+    // mockWebServer
+    testImplementation('com.squareup.okhttp3:okhttp:4.10.0')
+    testImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchService.java
+++ b/src/main/java/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchService.java
@@ -7,6 +7,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestTemplate;
@@ -24,6 +27,11 @@ public class KakaoAddressSearchService {
     @Value("${kakao.rest.api.key}")
     private String kakaoRestApiKey;
 
+    @Retryable(
+            value = {RuntimeException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 2000)
+    )
     public KakaoApiResponseDto requestAddressSearch(String address) {
 
         if(ObjectUtils.isEmpty(address)) return null;
@@ -34,5 +42,11 @@ public class KakaoAddressSearchService {
         HttpEntity httpEntity = new HttpEntity(headers);
         //kakao api 호출
         return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+    @Recover
+    public KakaoApiResponseDto recover(RuntimeException e, String address) {
+        log.error("All the retries failed. address: {}, error: {}", address, e.getMessage());
+        return null;
     }
 }

--- a/src/main/java/com/example/pharmacyrecommendation/config/RetryConfig.java
+++ b/src/main/java/com/example/pharmacyrecommendation/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.example.pharmacyrecommendation.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+}

--- a/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceRetryTest.groovy
+++ b/src/test/groovy/com/example/pharmacyrecommendation/api/service/KakaoAddressSearchServiceRetryTest.groovy
@@ -1,0 +1,76 @@
+package com.example.pharmacyrecommendation.api.service
+
+import com.example.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import com.example.pharmacyrecommendation.api.dto.DocumentDto
+import com.example.pharmacyrecommendation.api.dto.KakaoApiResponseDto
+import com.example.pharmacyrecommendation.api.dto.MetaDto
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+
+class KakaoAddressSearchServiceRetryTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private KakaoAddressSearchService kakaoAddressSearchService
+
+    @SpringBean
+    private KakaoUriBuilderService kakaoUriBuilderService = Mock()
+
+    private MockWebServer mockWebServer
+    private ObjectMapper mapper = new ObjectMapper()
+    private String inputAddress = "서울 성북구 종암로 10길"
+
+
+    def setup() {
+        mockWebServer = new MockWebServer()
+        mockWebServer.start()
+        println mockWebServer.port
+        println mockWebServer.url("/")
+    }
+
+    def cleanup() {
+        mockWebServer.shutdown()
+    }
+
+    def "requestAddressSearch retry success"() {
+        given:
+        def metaDto = new MetaDto(1)
+        def documentDto = DocumentDto.builder()
+                .addressName(inputAddress)
+                .build()
+        def expectedResponse = new KakaoApiResponseDto(metaDto, Arrays.asList(documentDto))
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .setBody(mapper.writeValueAsString(expectedResponse)))
+        def kakaoApiResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        kakaoApiResult.getDocumentList().size() == 1
+        kakaoApiResult.getMetaDto().totalCount == 1
+        kakaoApiResult.getDocumentList().get(0).getAddressName() == inputAddress
+    }
+
+    def "requestAddressSearch retry fail"() {
+        given:
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+
+        def result = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        result == null;
+    }
+}


### PR DESCRIPTION
 이 pr은 Kakao API 요청 실패의 경우 재수행 로직을 탈 수 있도록 하였다.

This closes #9 